### PR TITLE
Add discoverable paste UI with two side-by-side targets

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,117 @@
+# SPEC: Discoverable Paste UI for CSV Comparison
+
+Status: Draft
+Owner: detarmstrong@gmail.com
+Date: 2026-05-24
+
+## 1. Objective
+
+Make the existing clipboard-paste flow in Compare Datasets discoverable and usable by giving users a visible UI with two side-by-side paste targets — one per dataset — alongside the existing drag-and-drop area.
+
+### Problem
+
+Today (`src/DragNDropForm.tsx:61-121`) the app already accepts pasted CSV/TSV text, but the affordance is invisible:
+
+- There is no visual hint that pasting is supported.
+- A user must paste twice into the drop area to advance; the first paste produces no feedback.
+- The captured paste cannot be inspected, renamed, or cleared.
+- The existing source even flags this gap (`DragNDropForm.tsx:80`): `// got 2 pastes, ready for business // but how does the user know that?`.
+
+### Target user
+
+Same as today — general CSV users (analysts, ops, engineers) who routinely live in spreadsheets and copy ranges out of Excel/Google Sheets/Numbers. They reach for paste before they reach for "save as CSV → drag file."
+
+### Success criteria
+
+- A first-time user can complete a paste-based comparison without reading docs.
+- On page load, pressing `Cmd/Ctrl+V` immediately fills the left paste zone — no click required to "arm" the target. The left zone holds focus on mount.
+- After the first paste lands in the left zone, the user sees an unambiguous "now paste the second dataset" state on the right zone, and focus shifts there.
+- Both pasted datasets can be reviewed (row/column count, preview) and cleared before advancing.
+- Existing drag-and-drop file flow continues to work exactly as it does today.
+
+## 2. Commands
+
+No build-tooling changes. Use the existing scripts in `package.json`:
+
+| Task         | Command         |
+| ------------ | --------------- |
+| Dev server   | `npm start`     |
+| Production build | `npm run build` |
+| Run tests    | `npm test`      |
+
+Manual verification step (required before marking work complete):
+
+1. Run `npm start`.
+2. Open the app and **without clicking anything**, press `Cmd/Ctrl+V` with TSV content on the clipboard → left zone fills, focus moves to the right zone.
+3. Press `Cmd/Ctrl+V` again with CSV text → right zone fills, comparison flow advances.
+4. Drag two `.csv` files onto the existing drop area → confirm legacy flow still works.
+
+## 3. Project structure
+
+The feature lives within the current React app (`src/`). Minimal surface area:
+
+```
+src/
+  DragNDropForm.tsx        # extend: render PasteZones alongside FileUploader
+  PasteZones.tsx           # NEW: two side-by-side paste targets + state
+  PasteZone.tsx            # NEW: single zone (empty | filled | error)
+  util.ts                  # extend: shared paste-normalization helper
+                           #   (extract from DragNDropForm.handleOnPaste)
+  tests/
+    PasteZones.test.tsx    # NEW
+    PasteZone.test.tsx     # NEW
+```
+
+Rules:
+
+- Do not move or rename existing files unrelated to paste.
+- Keep `handleFileChange` (drag-drop) and the new paste handlers in separate code paths; both should ultimately call the same `props.loadCsv` + state-setting code, but via a small shared helper rather than copy-paste.
+
+## 4. Code style
+
+Follow the existing project conventions — do not introduce new ones.
+
+- **Language**: TypeScript, React function components with hooks (matches existing files).
+- **Formatting**: Prettier config in `package.json` (`singleQuote: true`, `semi: false`, `tabWidth: 2`, `trailingComma: 'es5'`). Do not change these.
+- **Styling**: MUI components (`@mui/material`) and `styles.scss` for layout, matching `DragNDropForm.tsx`. No new CSS-in-JS library.
+- **State**: local `useState` in the form component; lift only when a second consumer appears. Do not introduce Redux/Zustand/etc.
+- **Utilities**: `lodash` and `d3-dsv` are already in use — prefer them over hand-rolled equivalents.
+- **Naming**: zones are `dataset1` / `dataset2` in code; table names stay `clipboard1` / `clipboard2` to preserve the current SQL behavior unless the user provides a name.
+- **Comments**: only when the why is non-obvious (e.g., the `setTimeout` hack on `DragNDropForm.tsx:88` is the kind of thing that earns a comment — explain why, not what).
+
+## 5. Testing strategy
+
+- **Unit tests** (`src/tests/`): Jest + React Testing Library, matching existing test setup.
+  - Each `PasteZone` state renders the right affordance (empty prompt, filled summary, error message).
+  - `PasteZones` advances to the comparison step only after both zones are filled.
+  - TSV input (tab-delimited) is converted to CSV before being handed to `loadCsv`.
+  - Clearing a filled zone returns it to empty and prevents advancement.
+- **Manual / browser verification** (required because this is UI work): the four steps in §2. Type checks and unit tests verify code correctness; only a real browser verifies the feature works.
+- **Regression**: existing drag-and-drop flow still loads two CSVs and advances to key selection — must be checked manually before merge.
+
+## 6. Boundaries
+
+### Always do
+
+- Preserve the **browser-only privacy guarantee**. Pasted data must never leave the browser — no network calls, no logging to external services, no telemetry that includes paste contents. This is the core promise of the app and is non-negotiable.
+- Keep the **existing drag-and-drop flow unchanged**. The paste UI is additive. If the drag-drop behavior changes as a side effect, that's a regression.
+- Route both paste and drag-drop through the same downstream loader (`props.loadCsv` + the `setTableNames` / `setColumns` / `setOpen` calls) so the comparison step behaves identically regardless of input method.
+
+### Ask first
+
+- Adding a new npm dependency (the user did not rule it out, but did not green-light it either; default is to use the existing stack — React, MUI, lodash, d3-dsv, wa-sqlite).
+- Changing copy on the existing landing page beyond what's needed to introduce the paste zones.
+- Renaming `clipboard1` / `clipboard2` table names or other user-visible identifiers.
+- Adding analytics or any kind of usage tracking.
+
+### Never do
+
+- Send pasted data to any server or third-party endpoint.
+- Persist pasted data to `localStorage`, `IndexedDB`, cookies, or any storage that survives the tab.
+- Remove or hide the drag-and-drop area in favor of paste.
+- Add a build step, framework migration, or CSS framework change as part of this feature.
+
+## Resolved decisions
+
+- **Per-zone naming**: deferred to a later iteration. Stick with `clipboard1` / `clipboard2` for now.
+- **Paste on the drop area**: removed. Paste now lives exclusively in the two new zones, with the left zone focused on page load so `Cmd/Ctrl+V` works immediately. The drop area reverts to handling file drops only (its original purpose). This is a deliberate behavior change from today's "paste anywhere on the drop area" flow — the trade-off is one focused entry point over an invisible one.

--- a/src/DragNDropForm.tsx
+++ b/src/DragNDropForm.tsx
@@ -1,9 +1,9 @@
 import { Typography } from '@mui/material'
 import _ from 'lodash'
-import React, { useState, ClipboardEvent } from 'react'
+import React, { useState } from 'react'
 import { FileUploader } from 'react-drag-drop-files'
 import './styles.scss'
-import { TSVToCSV } from './util'
+import PasteZones from './PasteZones'
 
 interface FormProps {
   loadCsv: (name: string, csvText: string) => {}
@@ -15,7 +15,6 @@ interface FormProps {
 
 function Form(props: FormProps) {
   const [files, setFiles] = useState([])
-  const [pastes, setPastes] = useState([] as string[])
 
   const fileTypes = ['CSV']
 
@@ -58,68 +57,6 @@ function Form(props: FormProps) {
       })
   }
 
-  function handleOnPaste(e: ClipboardEvent<HTMLInputElement>) {
-    const clipboardData: string = e.clipboardData.getData('Text')
-    let clipboardDataNormalized: string = ''
-    // User will be pasting one string at a time. We reasonably expect either csv text or tab-delimited
-    // like would come from copying some range out of excel.
-    // Wait for 2 csv strings pasted before moving on
-    if (typeof clipboardData !== 'string') {
-      return false
-    }
-    //convert clipboard data to csv if it's not already
-    if (clipboardData.indexOf('\t') > 0) {
-      // TODO come up with a better heuristic
-      clipboardDataNormalized = TSVToCSV(clipboardData)
-    } else {
-      clipboardDataNormalized = clipboardData
-    }
-    pastes.push(clipboardDataNormalized)
-    setPastes(pastes)
-    // got 2 pastes, ready for business
-    // but how does the user know that?
-    if (pastes.length >= 2) {
-      props.setSheetNames(['clipboard1', 'clipboard2'])
-      let promises = _.map(pastes, (p, i) => {
-        return new Promise((resolve, reject) => {
-          // HACKY ALERT: I have to do the set timeout. If it's just resolve() with no setTimeout
-          // an error is encountered when running the sql
-          // WHY?
-          setTimeout(() => resolve(1), 1)
-        })
-          .then((result) => {
-            console.log('csv text', result, p)
-            return props.loadCsv('clipboard' + (i + 1), p)
-          })
-          .catch((error) => {
-            console.error('Error loading csv from paste', error)
-          })
-      })
-
-      Promise.allSettled(promises)
-        .then((results) => {
-          console.log('results', results)
-          let columns = _.map(results, (r) =>
-            r.status === 'fulfilled'
-              ? (r.value as { columns: string[] }).columns
-              : []
-          )
-
-          let tableNames = _.map(results, (r) =>
-            r.status === 'fulfilled'
-              ? (r.value as { tableName: string[] }).tableName
-              : []
-          ).flat()
-          props.setTableNames(tableNames)
-          props.setColumns(columns)
-          props.setOpen(true)
-        })
-        .catch((error) => {
-          console.error('Error on setting props after paste', error)
-        })
-    }
-  }
-
   const backgroundImage = `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='18' ry='18' stroke='%23000000FF' stroke-width='4' stroke-dasharray='6%2c 14' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e")`
   const borderRadius = `18px`
 
@@ -127,7 +64,6 @@ function Form(props: FormProps) {
     <div
       className="dragNDropContainer"
       style={{ backgroundImage: backgroundImage, borderRadius: borderRadius }}
-      onPaste={handleOnPaste}
     >
       <div className="box box-1">
         <div>
@@ -146,6 +82,20 @@ function Form(props: FormProps) {
 
   return (
     <form>
+      <PasteZones
+        loadCsv={props.loadCsv}
+        setColumns={props.setColumns}
+        setTableNames={props.setTableNames}
+        setSheetNames={props.setSheetNames}
+        setOpen={props.setOpen}
+      />
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ textAlign: 'center', mb: 1 }}
+      >
+        — or drag & drop CSV files —
+      </Typography>
       <FileUploader
         multiple={true}
         handleChange={handleFileChange}
@@ -172,12 +122,6 @@ function Form(props: FormProps) {
           3. Compare - view discrepancies and similarities
         </Typography>
       </div>
-      {/*<p>
-        {files
-          ? `File names: ${_.map(files, (f: { name }) => f.name).join()}`
-          : "no files uploaded yet"}
-      </p>
-        */}
     </form>
   )
 }

--- a/src/PasteZone.tsx
+++ b/src/PasteZone.tsx
@@ -1,0 +1,124 @@
+import React, {
+  ClipboardEvent,
+  KeyboardEvent,
+  MouseEvent,
+  useEffect,
+  useRef,
+} from 'react'
+import { Box, IconButton, Typography } from '@mui/material'
+import ClearIcon from '@mui/icons-material/Clear'
+
+export interface PasteZoneSummary {
+  rows: number
+  cols: number
+}
+
+export interface PasteZoneProps {
+  label: string
+  placeholder: string
+  summary: PasteZoneSummary | null
+  focused: boolean
+  onPaste: (rawText: string) => void
+  onClear: () => void
+  testId?: string
+}
+
+function PasteZone(props: PasteZoneProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (props.focused) {
+      containerRef.current?.focus()
+    }
+  }, [props.focused])
+
+  function handlePaste(e: ClipboardEvent<HTMLDivElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    const rawText = e.clipboardData.getData('Text')
+    props.onPaste(rawText)
+  }
+
+  function handleClear(e: MouseEvent) {
+    e.stopPropagation()
+    props.onClear()
+    containerRef.current?.focus()
+  }
+
+  // Allow keyboard activation to bring focus back to a zone (e.g. tabbing through).
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      containerRef.current?.focus()
+    }
+  }
+
+  const isFilled = props.summary !== null
+  const borderColor = props.focused
+    ? '#1976d2'
+    : isFilled
+    ? '#2e7d32'
+    : '#9e9e9e'
+
+  return (
+    <Box
+      ref={containerRef}
+      tabIndex={0}
+      role="region"
+      aria-label={`${props.label} paste target`}
+      data-testid={props.testId}
+      onPaste={handlePaste}
+      onKeyDown={handleKeyDown}
+      sx={{
+        flex: 1,
+        minHeight: 140,
+        border: `2px dashed ${borderColor}`,
+        borderRadius: '12px',
+        padding: '16px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'text',
+        outline: 'none',
+        transition: 'border-color 120ms ease-in-out',
+        backgroundColor: isFilled ? 'rgba(46, 125, 50, 0.04)' : 'transparent',
+        '&:focus': {
+          borderColor: '#1976d2',
+          boxShadow: '0 0 0 3px rgba(25, 118, 210, 0.2)',
+        },
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+        {props.label}
+      </Typography>
+
+      {isFilled ? (
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            {props.summary!.rows.toLocaleString()}{' '}
+            {props.summary!.rows === 1 ? 'row' : 'rows'} ·{' '}
+            {props.summary!.cols} {props.summary!.cols === 1 ? 'col' : 'cols'}
+          </Typography>
+          <IconButton
+            size="small"
+            aria-label={`Clear ${props.label}`}
+            onClick={handleClear}
+            sx={{ mt: 1 }}
+          >
+            <ClearIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      ) : (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ textAlign: 'center' }}
+        >
+          {props.placeholder}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default PasteZone

--- a/src/PasteZones.tsx
+++ b/src/PasteZones.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react'
+import { Box } from '@mui/material'
+import _ from 'lodash'
+
+import PasteZone, { PasteZoneSummary } from './PasteZone'
+import { normalizePastedTabular, summarizeCsv } from './util'
+
+export interface PasteZonesProps {
+  loadCsv: (name: string, csvText: string) => {}
+  setColumns: (cols: string[][]) => void
+  setTableNames: (tableNames: string[]) => void
+  setSheetNames: (sheetNames: string[]) => void
+  setOpen: (open: boolean) => void
+}
+
+type PasteSlot = { csv: string; summary: PasteZoneSummary } | null
+
+function PasteZones(props: PasteZonesProps) {
+  const [slots, setSlots] = useState<[PasteSlot, PasteSlot]>([null, null])
+  const [focusIndex, setFocusIndex] = useState<0 | 1>(0)
+
+  function handlePaste(index: 0 | 1, rawText: string) {
+    const normalized = normalizePastedTabular(rawText)
+    if (normalized === null) return
+
+    const summary = summarizeCsv(normalized)
+    const nextSlots: [PasteSlot, PasteSlot] = [slots[0], slots[1]]
+    nextSlots[index] = { csv: normalized, summary }
+    setSlots(nextSlots)
+
+    // Move focus to the other zone if it's still empty.
+    const otherIndex: 0 | 1 = index === 0 ? 1 : 0
+    if (nextSlots[otherIndex] === null) {
+      setFocusIndex(otherIndex)
+    }
+
+    if (nextSlots[0] !== null && nextSlots[1] !== null) {
+      advance(nextSlots as [NonNullable<PasteSlot>, NonNullable<PasteSlot>])
+    }
+  }
+
+  function handleClear(index: 0 | 1) {
+    const nextSlots: [PasteSlot, PasteSlot] = [slots[0], slots[1]]
+    nextSlots[index] = null
+    setSlots(nextSlots)
+    setFocusIndex(index)
+  }
+
+  function advance(
+    filled: [NonNullable<PasteSlot>, NonNullable<PasteSlot>]
+  ) {
+    const sheetNames = ['clipboard1', 'clipboard2']
+    props.setSheetNames(sheetNames)
+
+    const promises = filled.map((slot, i) =>
+      // Defer so React can flush state updates before SQLite work begins.
+      // (Matches the historical setTimeout hack in the previous paste handler.)
+      new Promise((resolve) => setTimeout(() => resolve(1), 1)).then(() =>
+        props.loadCsv(sheetNames[i], slot.csv)
+      )
+    )
+
+    Promise.allSettled(promises)
+      .then((results) => {
+        const columns = _.map(results, (r) =>
+          r.status === 'fulfilled'
+            ? (r.value as { columns: string[] }).columns
+            : []
+        )
+        const tableNames = _.map(results, (r) =>
+          r.status === 'fulfilled'
+            ? (r.value as { tableName: string }).tableName
+            : ''
+        )
+        props.setTableNames(tableNames as string[])
+        props.setColumns(columns)
+        props.setOpen(true)
+      })
+      .catch((error) => {
+        console.error('Error on loading CSV from paste', error)
+      })
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 2,
+        width: '100%',
+        maxWidth: 520,
+        margin: '24px auto 16px',
+      }}
+    >
+      <PasteZone
+        label="Dataset 1"
+        placeholder="Press Cmd/Ctrl+V to paste"
+        summary={slots[0]?.summary ?? null}
+        focused={focusIndex === 0 && slots[0] === null}
+        onPaste={(rawText) => handlePaste(0, rawText)}
+        onClear={() => handleClear(0)}
+        testId="paste-zone-1"
+      />
+      <PasteZone
+        label="Dataset 2"
+        placeholder={
+          slots[0] === null
+            ? 'Paste Dataset 1 first'
+            : 'Press Cmd/Ctrl+V to paste'
+        }
+        summary={slots[1]?.summary ?? null}
+        focused={focusIndex === 1 && slots[1] === null}
+        onPaste={(rawText) => handlePaste(1, rawText)}
+        onClear={() => handleClear(1)}
+        testId="paste-zone-2"
+      />
+    </Box>
+  )
+}
+
+export default PasteZones

--- a/src/tests/PasteZone.test.tsx
+++ b/src/tests/PasteZone.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PasteZone from '../PasteZone'
+
+function renderZone(overrides = {}) {
+  const props = {
+    label: 'Dataset 1',
+    placeholder: 'Press Cmd/Ctrl+V to paste',
+    summary: null as null | { rows: number; cols: number },
+    focused: false,
+    onPaste: jest.fn(),
+    onClear: jest.fn(),
+    testId: 'zone',
+    ...overrides,
+  }
+  const utils = render(<PasteZone {...props} />)
+  return { ...utils, props }
+}
+
+describe('PasteZone', () => {
+  it('renders the placeholder when empty', () => {
+    renderZone()
+    expect(screen.getByText('Dataset 1')).toBeInTheDocument()
+    expect(screen.getByText('Press Cmd/Ctrl+V to paste')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders row/column summary and a clear button when filled', () => {
+    renderZone({ summary: { rows: 250, cols: 4 } })
+    expect(screen.getByText(/250 rows · 4 cols/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Clear Dataset 1/i })
+    ).toBeInTheDocument()
+  })
+
+  it('uses singular wording when row or column count is 1', () => {
+    renderZone({ summary: { rows: 1, cols: 1 } })
+    expect(screen.getByText(/1 row · 1 col/)).toBeInTheDocument()
+  })
+
+  it('focuses the zone on mount when focused prop is true', () => {
+    renderZone({ focused: true })
+    expect(screen.getByTestId('zone')).toHaveFocus()
+  })
+
+  it('calls onPaste with the raw clipboard text', () => {
+    const { props } = renderZone({ focused: true })
+    fireEvent.paste(screen.getByTestId('zone'), {
+      clipboardData: { getData: () => 'a,b\n1,2' },
+    })
+    expect(props.onPaste).toHaveBeenCalledWith('a,b\n1,2')
+  })
+
+  it('calls onClear when the clear button is clicked', () => {
+    const { props } = renderZone({ summary: { rows: 3, cols: 2 } })
+    fireEvent.click(screen.getByRole('button', { name: /Clear Dataset 1/i }))
+    expect(props.onClear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/tests/PasteZones.test.tsx
+++ b/src/tests/PasteZones.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PasteZones from '../PasteZones'
+
+function setup(overrides = {}) {
+  const props = {
+    loadCsv: jest.fn(async (tableName: string) => ({
+      tableName,
+      columns: ['a', 'b'],
+    })),
+    setColumns: jest.fn(),
+    setTableNames: jest.fn(),
+    setSheetNames: jest.fn(),
+    setOpen: jest.fn(),
+    ...overrides,
+  }
+  const utils = render(<PasteZones {...props} />)
+  return { ...utils, props }
+}
+
+function paste(testId: string, text: string) {
+  fireEvent.paste(screen.getByTestId(testId), {
+    clipboardData: { getData: () => text },
+  })
+}
+
+describe('PasteZones', () => {
+  it('focuses the left zone on mount', () => {
+    setup()
+    expect(screen.getByTestId('paste-zone-1')).toHaveFocus()
+  })
+
+  it('shows a guidance placeholder on the right zone until the left is filled', () => {
+    setup()
+    expect(screen.getByText('Paste Dataset 1 first')).toBeInTheDocument()
+  })
+
+  it('moves focus to the right zone after the first paste lands', async () => {
+    setup()
+    paste('paste-zone-1', 'name,age\nAda,36\nGrace,85')
+    await waitFor(() =>
+      expect(screen.getByTestId('paste-zone-2')).toHaveFocus()
+    )
+    expect(screen.getByText(/2 rows · 2 cols/)).toBeInTheDocument()
+  })
+
+  it('normalizes TSV input to CSV before passing to loadCsv', async () => {
+    const { props } = setup()
+    paste('paste-zone-1', 'name\tage\nAda\t36')
+    paste('paste-zone-2', 'name\tcity\nAda\tLondon')
+
+    await waitFor(() => expect(props.setOpen).toHaveBeenCalledWith(true))
+
+    expect(props.loadCsv).toHaveBeenCalledTimes(2)
+    expect(props.loadCsv).toHaveBeenNthCalledWith(
+      1,
+      'clipboard1',
+      '"name","age"\n"Ada","36"'
+    )
+    expect(props.loadCsv).toHaveBeenNthCalledWith(
+      2,
+      'clipboard2',
+      '"name","city"\n"Ada","London"'
+    )
+  })
+
+  it('advances only after both zones are filled', async () => {
+    const { props } = setup()
+    paste('paste-zone-1', 'a,b\n1,2')
+    // First paste alone should not advance.
+    expect(props.setOpen).not.toHaveBeenCalled()
+
+    paste('paste-zone-2', 'a,c\n1,3')
+    await waitFor(() => expect(props.setOpen).toHaveBeenCalledWith(true))
+    expect(props.setSheetNames).toHaveBeenCalledWith([
+      'clipboard1',
+      'clipboard2',
+    ])
+  })
+
+  it('clearing a filled zone returns it to empty and refocuses it', async () => {
+    setup()
+    paste('paste-zone-1', 'a,b\n1,2')
+    await waitFor(() =>
+      expect(screen.getByTestId('paste-zone-2')).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear Dataset 1/i }))
+
+    expect(screen.queryByText(/1 row · 2 cols/)).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('paste-zone-1')).toHaveFocus()
+    )
+  })
+
+  it('ignores empty or whitespace-only pastes', () => {
+    const { props } = setup()
+    paste('paste-zone-1', '   \n  ')
+    expect(props.setOpen).not.toHaveBeenCalled()
+    expect(screen.getByText('Paste Dataset 1 first')).toBeInTheDocument()
+  })
+})

--- a/src/tests/util.test.js
+++ b/src/tests/util.test.js
@@ -1,4 +1,4 @@
-import { makeStringsUnique } from '../util';
+import { makeStringsUnique, normalizePastedTabular, summarizeCsv } from '../util';
 
 describe('makeStringsUnique', () => {
   it('should make duplicate strings unique by appending numbers', () => {
@@ -29,5 +29,59 @@ describe('makeStringsUnique', () => {
     const input = [];
     const expected = [];
     expect(makeStringsUnique(input)).toEqual(expected);
+  });
+});
+
+describe('normalizePastedTabular', () => {
+  it('returns CSV input unchanged (apart from trimming)', () => {
+    const csv = 'name,age\nAda,36\nGrace,85';
+    expect(normalizePastedTabular(csv)).toBe(csv);
+  });
+
+  it('converts tab-delimited input to CSV', () => {
+    const tsv = 'name\tage\nAda\t36';
+    expect(normalizePastedTabular(tsv)).toBe('"name","age"\n"Ada","36"');
+  });
+
+  it('trims surrounding whitespace before deciding format', () => {
+    expect(normalizePastedTabular('  \n  name,age\nAda,36\n\n')).toBe(
+      'name,age\nAda,36'
+    );
+  });
+
+  it('returns null for non-strings', () => {
+    expect(normalizePastedTabular(undefined)).toBeNull();
+    expect(normalizePastedTabular(null)).toBeNull();
+    expect(normalizePastedTabular(42)).toBeNull();
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(normalizePastedTabular('')).toBeNull();
+    expect(normalizePastedTabular('   \n\t  ')).toBeNull();
+  });
+});
+
+describe('summarizeCsv', () => {
+  it('counts data rows (excluding header) and columns', () => {
+    expect(summarizeCsv('name,age\nAda,36\nGrace,85')).toEqual({
+      rows: 2,
+      cols: 2,
+    });
+  });
+
+  it('handles header-only input as zero data rows', () => {
+    expect(summarizeCsv('name,age')).toEqual({ rows: 0, cols: 2 });
+  });
+
+  it('handles CRLF line endings', () => {
+    expect(summarizeCsv('a,b,c\r\n1,2,3\r\n4,5,6')).toEqual({
+      rows: 2,
+      cols: 3,
+    });
+  });
+
+  it('returns zeros for empty input', () => {
+    expect(summarizeCsv('')).toEqual({ rows: 0, cols: 0 });
+    expect(summarizeCsv('   ')).toEqual({ rows: 0, cols: 0 });
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,6 +23,30 @@ export function makeStringsUnique(strings: string[]): string[] {
   return uniqueStrings;
 }
 
+// Quick row/column estimate for the paste preview UI. Approximate by design:
+// counts newlines for rows and commas in the first line for columns. Fails for
+// CSVs with embedded newlines or commas inside quoted cells, but those are rare
+// in paste-from-spreadsheet flows and the authoritative parse happens downstream.
+export function summarizeCsv(csvText: string): { rows: number; cols: number } {
+  const trimmed = csvText.trim()
+  if (trimmed.length === 0) return { rows: 0, cols: 0 }
+  const lines = trimmed.split(/\r?\n/)
+  const cols = (lines[0].match(/,/g) || []).length + 1
+  const rows = Math.max(0, lines.length - 1)
+  return { rows, cols }
+}
+
+// Normalize pasted tabular text into CSV. Users typically paste a range from
+// Excel/Google Sheets (TSV) or already-comma-separated text. Any tab in the
+// body is treated as TSV; otherwise the text is assumed already CSV.
+// Returns null when input isn't a non-empty string.
+export function normalizePastedTabular(rawText: unknown): string | null {
+  if (typeof rawText !== 'string') return null
+  const trimmed = rawText.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.includes('\t') ? TSVToCSV(trimmed) : trimmed
+}
+
 export function TSVToCSV(TSVText: string): string {
   // Split the input text into rows based on newline characters
   const rows = TSVText.trim().split('\n');


### PR DESCRIPTION
## Summary
- Adds two visible paste zones above the existing drag-drop area; the left zone is focused on page load so `Cmd/Ctrl+V` works immediately, and focus shifts to the right zone after the first paste lands
- Removes the legacy `onPaste` handler from the drop area — paste now lives exclusively in the new zones (the drop area reverts to file drops only)
- Extracts paste-normalization (`normalizePastedTabular`) and a lightweight CSV row/col estimator (`summarizeCsv`) into `src/util.ts`
- Adds `SPEC.md` documenting objective, commands, structure, style, testing, and boundaries for this feature

## Test plan
- [x] `npm test` — 38 tests pass across 5 suites
- [x] `npm run build` — production build compiles cleanly
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] Manual browser walkthrough (SPEC.md §2):
  - Open the app, press `Cmd/Ctrl+V` without clicking — left zone fills, focus moves to right
  - Press `Cmd/Ctrl+V` again — right zone fills, comparison flow advances
  - Drag two `.csv` files onto the drop area — legacy flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)